### PR TITLE
Update README to use augroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This script provides a command which will attempt to guess the correct indent se
 
 May also be used in an autocommand. For example, you might want to put this in your `vimrc`:
 
-    autocmd BufReadPost *  DetectIndent 
+    augroup DetectIndent
+       au!
+       autocmd BufReadPost *  DetectIndent
+    augroup END
 
 ## Options
 


### PR DESCRIPTION
Using only the autocmd would cause repeated executions of `DetectIndent` if the user source the `vimrc` multiple times.

I know it is quite simple for an advanced user to spot and change it, but it could be helpful to the new/lazy user.
